### PR TITLE
use phantomjs 1.9.8 - install errors with 1.9.2-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "handlebars": "1.0.12",
     "wrench": "1.5.4",
     "mocha": "1.13.0",
-    "phantomjs": "1.9.2-2",
+    "phantomjs": "1.9.8",
     "mocha-phantomjs": "3.1.5",
     "commander": "2.0.0",
     "serial": "0.0.6",


### PR DESCRIPTION
@prudhvi @jden 

Bumping the version of phantomjs, since 1.9.2-2 seems unavailable for download.